### PR TITLE
Dynamically add enums to service clients on retrieval

### DIFF
--- a/gapic/ads-templates/%namespace/%name/%version/__init__.py.j2
+++ b/gapic/ads-templates/%namespace/%name/%version/__init__.py.j2
@@ -28,6 +28,16 @@ _lazy_type_to_package_map = {
 {%- endfor %}
 }
 
+class _EnumGetter:
+    def __getattr__(self, name):
+        return __getattr__(name)
+
+
+@property
+def _enum_getter(self):
+    """Getter utility that attaches all Enum classes to a given object."""
+    return _EnumGetter()
+
 
 # Background on how this behaves: https://www.python.org/dev/peps/pep-0562/
 def __getattr__(name):  # Requires Python >= 3.7
@@ -37,7 +47,8 @@ def __getattr__(name):  # Requires Python >= 3.7
     elif name in _lazy_type_to_package_map:
         module = importlib.import_module(f'{_lazy_type_to_package_map[name]}')
         klass = getattr(module, name)
-        {# new_klass = type(name, (klass,), {'__doc__': klass.__doc__}) #}
+        if name.endswith('ServiceClient'):
+            klass = type(name, (klass,), dict(enums=_enum_getter))
         globals()[name] = klass
         return klass
     else:


### PR DESCRIPTION
Possible implementation to achieve this interface:

```python
ga_service = client.get_service('GoogleAdsService')
ad_status = ga_service.enums.AdGroupStatusEnum.AdGroupStatus.PAUSED
```